### PR TITLE
adds shorter executable name

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "tool"
   ],
   "bin": {
-    "checkit": "index.js"
+    "checkit": "index.js",
+    "cio": "index.js"
   },
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
Because sometimes I don't even have time to type `checkit` ;)
Plus, it's an acronym for `check-it-out`.  Win-win!