### PR TITLE
CIO-257 Moved appending of Table and Container only on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,7 @@ Each issue fixed should contain one bullet summarizing the work done.
 <hr />
 
 ## [Unreleased]
-* [CIO-257](https://github.com/jwu910/check-it-out/issues/257) 
-Adding Table and Statusbar container only on promise resolution which is returned from fetching git refs.
-Moved all the screen appends to happen on the initial load.
-Removed ``loadingDoalog`` from line ``118`` as we are already ``calling loadingDialog.stop()`` after successful checkout.
+* [CIO-257](https://github.com/jwu910/check-it-out/issues/257) Fix append order to address missing load screen bug
 
 
 ## [[2.0.0]](https://github.com/jwu910/check-it-out/releases/tag/v2.0.0) - 2019-02-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ Each issue fixed should contain one bullet summarizing the work done.
 <hr />
 
 ## [Unreleased]
-* [CIO-257](https://github.com/jwu910/check-it-out/issues/257) Adding Table and Statusbar container only on promise resolution which is returned from fetching git refs.
-
+* [CIO-257](https://github.com/jwu910/check-it-out/issues/257) 
+Adding Table and Statusbar container only on promise resolution which is returned from fetching git refs.
+Moved all the screen appends to happen on the initial load.
+Removed ``loadingDoalog`` from line ``118`` as we are already ``calling loadingDialog.stop()`` after successful checkout.
 
 
 ## [[2.0.0]](https://github.com/jwu910/check-it-out/releases/tag/v2.0.0) - 2019-02-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Each issue fixed should contain one bullet summarizing the work done.
 <hr />
 
 ## [Unreleased]
+* [CIO-257](https://github.com/jwu910/check-it-out/issues/257) Adding Table and Statusbar container only on promise resolution which is returned from fetching git refs.
+
 
 
 ## [[2.0.0]](https://github.com/jwu910/check-it-out/releases/tag/v2.0.0) - 2019-02-11

--- a/src/app.js
+++ b/src/app.js
@@ -86,6 +86,7 @@ export const start = args => {
       remoteList = data[1];
 
       refreshTable(currentRemote);
+
       notifyMessage(messageCenter, 'log', 'Loaded successfully');
     })
     .catch(err => {

--- a/src/app.js
+++ b/src/app.js
@@ -73,7 +73,8 @@ export const start = args => {
       branchPayload = data[0];
 
       remoteList = data[1];
-
+      screen.append(branchTable);
+      screen.append(statusBarContainer);
       refreshTable(currentRemote);
 
       notifyMessage(messageCenter, 'log', 'Loaded successfully');
@@ -134,9 +135,6 @@ export const start = args => {
         notifyMessage(messageCenter, 'error', error, 5);
       });
   });
-
-  screen.append(branchTable);
-  screen.append(statusBarContainer);
 
   statusBar.append(statusBarText);
   statusBar.append(statusHelpText);

--- a/src/app.js
+++ b/src/app.js
@@ -60,6 +60,17 @@ export const start = args => {
   let currentRemote = 'heads';
   let remoteList = [];
 
+  screen.append(branchTable);
+  screen.append(statusBarContainer);
+
+  statusBar.append(statusBarText);
+  statusBar.append(statusHelpText);
+
+  statusBarContainer.append(messageCenter);
+  statusBarContainer.append(statusBar);
+  statusBarContainer.append(messageCenter);
+  statusBarContainer.append(helpDialogue);
+
   screen.append(loadDialogue);
 
   loadDialogue.load(' Building project reference lists');
@@ -73,10 +84,8 @@ export const start = args => {
       branchPayload = data[0];
 
       remoteList = data[1];
-      screen.append(branchTable);
-      screen.append(statusBarContainer);
-      refreshTable(currentRemote);
 
+      refreshTable(currentRemote);
       notifyMessage(messageCenter, 'log', 'Loaded successfully');
     })
     .catch(err => {
@@ -115,8 +124,6 @@ export const start = args => {
   screen.key('C-r', () => {
     branchTable.clearItems();
 
-    screen.append(loadDialogue);
-
     loadDialogue.load(' Fetching refs...');
 
     notifyMessage(messageCenter, 'log', 'Fetching');
@@ -135,14 +142,6 @@ export const start = args => {
         notifyMessage(messageCenter, 'error', error, 5);
       });
   });
-
-  statusBar.append(statusBarText);
-  statusBar.append(statusHelpText);
-
-  statusBarContainer.append(messageCenter);
-  statusBarContainer.append(statusBar);
-  statusBarContainer.append(messageCenter);
-  statusBarContainer.append(helpDialogue);
 
   process.on('SIGWINCH', () => {
     screen.emit('resize');
@@ -171,8 +170,6 @@ export const start = args => {
     const gitRemote = selection[1];
 
     branchTable.clearItems();
-
-    screen.append(loadDialogue);
 
     loadDialogue.load(` Checking out ${gitBranch}...`);
 


### PR DESCRIPTION
Fixes #257 
Appending the ``branchTable`` and ``statusBarContainer`` after fetching refs from the git 

## Description
``statusBarContainer`` and ``branchTable`` are being appended to the screen without waiting for the refs promise to resolve, so it is making the ``Loading`` screen disappear immediately, moving that to append once the promise is resolved solves the issue.

Issue Link - https://github.com/jwu910/check-it-out/issues/257

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
