### PR TITLE
docs: change mention of master to main in the documentation (Issue #491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Minor patch to fix version text
 
 Received some amazing help from @drewbrokke cleaning up a ton of old spaghetti code and really diving in to the importance of typing with me. With his help, we're finally able to add a popularly requested feature to search and filter our branches.
 
-Head over to the [README](https://github.com/jwu910/check-it-out/blob/master/README.md) to take a look at the new feature. This new feature is being released as a major change because we are now developing and testing on latest LTS versions of node only and not checking for compatibility with older versions of Node. I hope this doesn't affect too many people, but if there are some changes we can add in to help with the compatibility, I encourage issues be opened--and I would be happy to discuss and review any PRs.
+Head over to the [README](https://github.com/jwu910/check-it-out/blob/main/README.md) to take a look at the new feature. This new feature is being released as a major change because we are now developing and testing on latest LTS versions of node only and not checking for compatibility with older versions of Node. I hope this doesn't affect too many people, but if there are some changes we can add in to help with the compatibility, I encourage issues be opened--and I would be happy to discuss and review any PRs.
 
 ### Added
 
@@ -90,7 +90,7 @@ Head over to the [README](https://github.com/jwu910/check-it-out/blob/master/REA
 -   [CIO-0] Move away from Promises in source code in lieu of async/await
 -   [CIO-315](https://github.com/jwu910/check-it-out/issues/315) Make CIO commitizen friendly
 -   [CIO-413](https://github.com/jwu910/check-it-out/issues/413) Update dependabot configs - No longer testing compatibility for node 6 and 7 on travis
--   [CIO-454](https://github.com/jwu910/check-it-out/issues/454) Develop against master
+-   [CIO-454](https://github.com/jwu910/check-it-out/issues/454) Develop against main
 
 ### Removed
 
@@ -207,7 +207,7 @@ Added CIO to some issue aggregating sites. Pretty neat! Started utilizing [hacto
 
 Minor bug fix and add CIO logo.
 
-Roadmap: Add gh-page source code back into master branch and use (probably) gatsby for their templating abilities to hopefully streamline updating the readme -> gh-page conversion.
+Roadmap: Add gh-page source code back into main branch and use (probably) gatsby for their templating abilities to hopefully streamline updating the readme -> gh-page conversion.
 
 ### Added
 
@@ -273,7 +273,7 @@ Found some documentation issues. Had to update readme image paths. Currently NPM
 
 ### Fixed
 
--   [CIO-235](https://github.com/jwu910/check-it-out/issues/235) Change Dangerfile. PR to master will fail.
+-   [CIO-235](https://github.com/jwu910/check-it-out/issues/235) Change Dangerfile. PR to main will fail.
 
 <hr />
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ To initiate a commit, stage your changes and run `git cz` if you have commitizen
 
 ## Pull Request Process
 
-1.  Before submitting a PR, check the issues to make sure that the current fix has not been resolved/closed and be sure your code contains the latest code from master.
+1.  Before submitting a PR, check the issues to make sure that the current fix has not been resolved/closed and be sure your code contains the latest code from main.
 2.  Naming conventions:
 
     - Branch names should follow the PROJECT-ISSUE convention with an optional short description. e.g. `CIO-60-contributing-guidelines`
 
 3.  Update README and with any necessary changes such as adding hot keys, updating instructions, fixing help text, etc.
 4.  Reference the issue the PR aims to resolve using the hash tag at the beginning of your PR description. e.g. `Fixes #52`
-5.  Please send any pull requests to **master** branch.
+5.  Please send any pull requests to **main** branch.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 		<img alt="first-timers-only" src="https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)">
 	</a>
 	<a href="https://travis-ci.org/jwu910/check-it-out">
-		<img alt="Build Status" src="https://travis-ci.org/jwu910/check-it-out.svg?branch=master">
+		<img alt="Build Status" src="https://travis-ci.org/jwu910/check-it-out.svg?branch=main">
 	</a>
 	<a href="https://www.npmjs.org/package/check-it-out">
 		<img alt="Downloads per week" src="https://img.shields.io/npm/dw/localeval.svg">
@@ -159,7 +159,7 @@ checkit --reset-config
 ## Contributing
 Please refer to the [Contributing Guidelines](./CONTRIBUTING.md) before contributing.
 
-:rotating_light: *Recent change!* In the past I asked to send pull requests to my development branch, but that is being changed. I will be dropping the `development` branch and keeping just `master` as the default branch. Please take note if you are looking to submit a PR. Thanks!
+:rotating_light: *Recent change!* In the past I asked to send pull requests to my development branch, but that is being changed. I will be dropping the `development` branch and keeping just `main` as the default branch. Please take note if you are looking to submit a PR. Thanks!
 
 See the rest of our [issues](https://github.com/jwu910/check-it-out/issues)
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ checkit --reset-config
 ## Contributing
 Please refer to the [Contributing Guidelines](./CONTRIBUTING.md) before contributing.
 
-:rotating_light: *Recent change!* In the past I asked to send pull requests to my development branch, but that is being changed. I will be dropping the `development` branch and keeping just `main` as the default branch. Please take note if you are looking to submit a PR. Thanks!
-
 See the rest of our [issues](https://github.com/jwu910/check-it-out/issues)
 
 ## Contributors


### PR DESCRIPTION
<!--- Thank you for submitting a pull request! Please use the following template to draft your PR. If you have any questions, please do not hesitate to ask- we are happy to help. -->

## Description
<!--- Describe your changes -->
This pull request includes changes made by @CatherineNjenga in pull request #507, as well as my own changes to remove an outdated warning blob in the Contributing section of README.md (as requested in [this comment](https://github.com/jwu910/check-it-out/pull/507#pullrequestreview-1096624541)). @CatherineNjenga's changes include updating all mention of "master" to "main" in the documentation.

With @jwu910's approval, I have squashed and merged @CatherineNjenga's commits into one and reworded the commit message to follow the commitizen conventions. 

<!--- Include a reference to the issue this fixes with #XXX e.g. #123 -->
Fixes #491 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My commits follow the [commitizen](https://github.com/commitizen/cz-cli#philosophy) commit convention
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
