### PR TITLE
feat: allow deleting branches with 'd' (with a confirmation prompt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See a git log for the highlighted ref by pressing <kbd>SPACE</kbd>
 | <kbd>enter</kbd>                                                 | Select highlighted item                             |
 | <kbd>y</kbd>                                                     | Copy highlighted item                               |
 | <kbd>space</kbd>                                                 | Git log                                             |
+| <kbd>d</kbd>                                                     | Prompt to delete highlighted item                   |
 | <kbd>&</kbd>                                                     | Filter lines - enter blank search to show all lines |
 | <kbd>/</kbd>                                                     | Search Lines                                        |
 | <kbd>n</kbd>                                                     | Jump to next search result                          |

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import * as config from "./utils/config.js";
 import {
   closeGitResponse,
   doCheckoutBranch,
+  forceDeleteBranch,
   doFetchBranches,
   getRefData,
 } from "./utils/git.js";
@@ -301,6 +302,39 @@ export const start = async (args: string[]) => {
     } catch (error) {
       logger.error(`Unable to copy : ${JSON.stringify(error)}`);
     }
+  });
+
+  branchTable.key("d", function () {
+    const selection = parseSelection(
+      branchTable.items[branchTable.selected].content,
+    );
+    const branchName = selection[2];
+
+    if (state.currentRemoteIndex !== 0) {
+      logger.error("Branch deletion is only available on heads");
+      return;
+    }
+
+    getPrompt(
+      `Are you sure you want to force delete ${branchName}? (only y is accepted)`,
+      async (value: string) => {
+        if (value === "y") {
+          try {
+            await forceDeleteBranch(branchName);
+
+            process.stdout.write(
+              `Successfully deleted branch ${chalk.bold(branchName)}\n`,
+            );
+
+            process.exit(0);
+          } catch (error) {
+            logger.error(`Failed to delete branch ${branchName}`);
+          }
+        } else {
+          logger.log("Skipping deletion");
+        }
+      },
+    );
   });
 
   branchTable.focus();

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -128,6 +128,18 @@ export const doFetchBranches = () => {
 };
 
 /**
+ * Force delete the given branch
+ *
+ * @param selectedBranch
+ * @returns {Promise<string>}
+ */
+export const forceDeleteBranch = (selectedBranch: string) => {
+  const args = ["branch", "-D", selectedBranch];
+
+  return execGit(args);
+};
+
+/**
  * Format output from getBranchesFrom() and return an array of arrays containing
  * formatted lines for the data table.
  *

--- a/src/utils/helpText.ts
+++ b/src/utils/helpText.ts
@@ -13,6 +13,7 @@ export const helpText = (): Array<Array<string>> => {
     [chalk.bold("enter"), "Select highlighted item"],
     [chalk.bold("y"), "Copy highlighted item"],
     [chalk.bold("space"), "Git log"],
+    [chalk.bold("d"), "Prompt to delete highlighted item"],
     [chalk.bold("&"), "Filter lines - enter blank search to show all lines"],
     [chalk.bold("/"), "Search lines"],
     [chalk.bold("n"), "Jump to next search result"],


### PR DESCRIPTION
fix #530

## Description
This PR adds delete functionality by typing in `d` when on the heads remote. The user is prompted to enter `y` to confirm deletion and exits successfully after deleting the branch (similar to selecting a branch to avoid stale info being shown to the user).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My commits follow the [commitizen](https://github.com/commitizen/cz-cli#philosophy) commit convention
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
